### PR TITLE
fix(switch.css): adds missing font-family: var(--font-stack-primary) …

### DIFF
--- a/packages/forma-36-react-components/src/components/Switch/Switch.css
+++ b/packages/forma-36-react-components/src/components/Switch/Switch.css
@@ -51,6 +51,7 @@
 }
 
 .Switch__label {
+  font-family: var(--font-stack-primary);
   color: var(--color-text-dark);
   display: flex;
   align-items: center;


### PR DESCRIPTION
# Purpose of PR

Fixes CSS issue with `<Switch labelText>` where font-family is default browser font stack and not using `var(--font-stack-primary)`

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
